### PR TITLE
Add integration specs for view and fix n+1 problem for PR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'turbo-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem 'capybara', '~> 3.35'
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 5.0'
@@ -29,6 +30,5 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem 'capybara'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  capybara
+  capybara (~> 3.35)
   debug
   factory_bot_rails
   importmap-rails

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ rspec spec --format documentation
 - Twitter: [@Ksupreeti](https://twitter.com/Ksupreeti)
 - LinkedIn: [Supreeti](https://www.linkedin.com/in/supreeti-kushwaha-23336232/)
 
+ **Md. Porag Sarkar**
+- GitHub: [@porag-m06](https://github.com/porag-m06)
+- Twitter: [@twitterhandle](https://twitter.com/rarebird06)
+- LinkedIn: [LinkedIn](https://www.linkedin.com/in/muhammad-porag-nsu-cse/)
+
 <!-- FUTURE FEATURES -->
 
 ## 🔭 Future Features <a name="future-features"></a>

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :post_params, only: [:create]
 
   def index
-    @user = User.find(params[:user_id])
+    @user = User.includes(posts: :comments).find(params[:user_id])
     @post = @user.posts
   end
 

--- a/spec/integration/posts_index_spec.rb
+++ b/spec/integration/posts_index_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'Posts#details', type: :integration do
+  before(:all) do
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+    @tom = User.create(name: 'Tom', photo: 'https://placehold.co/200x133', bio: 'Teacher from Mexico.',
+                       post_counter: 0)
+    @first_post = Post.create(author: @tom, title: 'Hello', text: 'This is my first post', comment_counter: 0,
+                              like_counter: 0)
+    @lilly = User.create(name: 'Lilly', photo: 'https://placehold.co/200x133', bio: 'Teacher from Poland.',
+                         post_counter: 0)
+    @second_post = Post.create(author: @lilly, title: 'Hi Word!', text: 'Lets talk', comment_counter: 0,
+                               like_counter: 0)
+    Comment.create(post: @first_post, author: @lilly, text: 'Hi Tom!')
+    Comment.create(post: @second_post, author: @tom, text: 'Hi Lili!')
+    @user = User.all
+    @post = Post.all
+  end
+
+  it 'I can see the post\'s title.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@first_post.title)
+  end
+
+  it 'I can see who wrote the post.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@tom.name)
+  end
+
+  it 'I can see how many comments it has.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content("Comments: #{@first_post.comment_counter},")
+  end
+
+  it 'I can see how many likes it has.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content("Likes: #{@first_post.like_counter}")
+  end
+
+  it 'I can see the post body.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@first_post.text)
+  end
+
+  it 'I can see the username of each commentor.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    @first_post.comments.each do |comment|
+      expect(page).to have_content(comment.author.name)
+    end
+  end
+
+  it 'I can see see how many comments a post has.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    @first_post.comments.each do |comment|
+      expect(page).to have_content(comment.text)
+    end
+  end
+end

--- a/spec/integration/posts_show_spec.rb
+++ b/spec/integration/posts_show_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'Posts#details', type: :integration do
+  before(:all) do
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+    @tom = User.create(name: 'Tom', photo: 'https://placehold.co/200x133', bio: 'Teacher from Mexico.',
+                       post_counter: 0)
+    @first_post = Post.create(author: @tom, title: 'Hello', text: 'This is my first post', comment_counter: 0,
+                              like_counter: 0)
+    @lilly = User.create(name: 'Lilly', photo: 'https://placehold.co/200x133', bio: 'Teacher from Poland.',
+                         post_counter: 0)
+    @second_post = Post.create(author: @lilly, title: 'Hi Word!', text: 'Lets talk', comment_counter: 0,
+                               like_counter: 0)
+    Comment.create(post: @first_post, author: @lilly, text: 'Hi Tom!')
+    Comment.create(post: @second_post, author: @tom, text: 'Hi Lili!')
+    @users = User.all
+    @posts = Post.all
+  end
+
+  it 'I can see the post\'s title.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@first_post.title)
+  end
+
+  it 'I can see who wrote the post.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@tom.name)
+  end
+
+  it 'I can see how many comments it has.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content("Comments: #{@first_post.comment_counter},")
+  end
+
+  it 'I can see how many likes it has.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content("Likes: #{@first_post.like_counter}")
+  end
+
+  it 'I can see the post body.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    expect(page).to have_content(@first_post.text)
+  end
+
+  it 'I can see the username of each commentor.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    @first_post.comments.each do |comment|
+      expect(page).to have_content(comment.author.name)
+    end
+  end
+
+  it 'I can see the comment each commentor left.' do
+    visit "/users/#{@tom.id}/posts/#{@first_post.id}"
+    @first_post.comments.each do |comment|
+      expect(page).to have_content(comment.text)
+    end
+  end
+end

--- a/spec/integration/users_index_spec.rb
+++ b/spec/integration/users_index_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Users#index', type: :integration do
+  before(:all) do
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+    @tom = User.create(name: 'Tom', photo: 'https://placehold.co/200x133', bio: 'Teacher from Mexico.',
+                       post_counter: 0)
+    Post.create(author: @tom, title: 'Hello', text: 'This is my first post', comment_counter: 0, like_counter: 0)
+    @lilly = User.create(name: 'Lilly', photo: 'https://placehold.co/200x133', bio: 'Teacher from Poland.',
+                         post_counter: 0)
+    @users = User.all
+  end
+
+  it 'I can see the username of all other users.' do
+    visit '/users'
+    expect(page).to have_content('Tom')
+    expect(page).to have_content('Lilly')
+  end
+
+  it 'I can see the profile picture for each user.' do
+    visit '/users'
+    @users.each do
+      expect(page).to have_css("img[src='https://placehold.co/200x133']")
+    end
+  end
+
+  it 'I can see the number of posts each user has written.' do
+    visit '/users'
+    @users.each do |user|
+      expect(page).to have_content("Number of posts: #{user.post_counter}")
+    end
+  end
+
+  it 'When I click on a user, I am redirected to that user\'s show page.' do
+    visit '/users'
+    click_link 'Tom'
+    expect(page).to have_current_path("/users/#{@tom.id}")
+  end
+end

--- a/spec/integration/users_show_spec.rb
+++ b/spec/integration/users_show_spec.rb
@@ -1,0 +1,1 @@
+require 'rails_helper'

--- a/spec/integration/users_show_spec.rb
+++ b/spec/integration/users_show_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Users#shows', type: :integration do
                          post_counter: 0)
     @users = User.all
   end
-  
+
   it 'I can see the user\'s profile picture..' do
     visit "/users/#{@tom.id}"
     expect(page).to have_css("img[src='https://placehold.co/200x133']")
@@ -33,23 +33,23 @@ RSpec.describe 'Users#shows', type: :integration do
     posts = @users[0].recent_posts
     posts.each do |post|
       expect(page).to have_content(post.title)
- end
-end
-it 'I can see a button that lets me view all of a user\'s posts.' do
-  visit "/users/#{@tom.id}"
-  expect(page).to have_content('See all posts')
-end
-it 'When I click a user\'s post, it redirects me to that post\'s show page.' do
-  visit "/users/#{@tom.id}"
-  posts = @users[0].recent_posts
-  unless posts.nil? || posts.empty?
-    click_link posts[0].title
-    expect(page).to have_current_path("/users/#{@tom.id}/posts/#{posts[0].id}")
+    end
   end
-end
-it 'When I click to see all posts, it redirects me to the user\'s post\'s index page.' do
-  visit "/users/#{@tom.id}"
-  click_link 'See all posts'
-  expect(page).to have_current_path("/users/#{@tom.id}/posts")
-end
+  it 'I can see a button that lets me view all of a user\'s posts.' do
+    visit "/users/#{@tom.id}"
+    expect(page).to have_content('See all posts')
+  end
+  it 'When I click a user\'s post, it redirects me to that post\'s show page.' do
+    visit "/users/#{@tom.id}"
+    posts = @users[0].recent_posts
+    unless posts.nil? || posts.empty?
+      click_link posts[0].title
+      expect(page).to have_current_path("/users/#{@tom.id}/posts/#{posts[0].id}")
+    end
+  end
+  it 'When I click to see all posts, it redirects me to the user\'s post\'s index page.' do
+    visit "/users/#{@tom.id}"
+    click_link 'See all posts'
+    expect(page).to have_current_path("/users/#{@tom.id}/posts")
+  end
 end

--- a/spec/integration/users_show_spec.rb
+++ b/spec/integration/users_show_spec.rb
@@ -11,4 +11,27 @@ RSpec.describe 'Users#shows', type: :integration do
                          post_counter: 0)
     @users = User.all
   end
+  
+  it 'I can see the user\'s profile picture..' do
+    visit "/users/#{@tom.id}"
+    expect(page).to have_css("img[src='https://placehold.co/200x133']")
+  end
+  it 'I can see the user\'s username.' do
+    visit "/users/#{@tom.id}"
+    expect(page).to have_content('Tom')
+  end
+  it 'I can see the number of posts the user has written.' do
+    visit "/users/#{@tom.id}"
+    expect(page).to have_content('Number of posts: 1')
+  end
+  it 'I can see the user\'s bio.' do
+    visit "/users/#{@tom.id}"
+    expect(page).to have_content('Teacher from Mexico.')
+  end
+  it 'I can see the user\'s first 3 posts.' do
+    visit "/users/#{@tom.id}"
+    posts = @users[0].recent_posts
+    posts.each do |post|
+      expect(page).to have_content(post.title)
+ end
 end

--- a/spec/integration/users_show_spec.rb
+++ b/spec/integration/users_show_spec.rb
@@ -1,1 +1,14 @@
 require 'rails_helper'
+RSpec.describe 'Users#shows', type: :integration do
+  before(:all) do
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+    @tom = User.create(name: 'Tom', photo: 'https://placehold.co/200x133', bio: 'Teacher from Mexico.',
+                       post_counter: 0)
+    Post.create(author: @tom, title: 'Hello', text: 'This is my first post', comment_counter: 0, like_counter: 0)
+    @lilly = User.create(name: 'Lilly', photo: 'https://placehold.co/200x133', bio: 'Teacher from Poland.',
+                         post_counter: 0)
+    @users = User.all
+  end
+end

--- a/spec/integration/users_show_spec.rb
+++ b/spec/integration/users_show_spec.rb
@@ -35,3 +35,21 @@ RSpec.describe 'Users#shows', type: :integration do
       expect(page).to have_content(post.title)
  end
 end
+it 'I can see a button that lets me view all of a user\'s posts.' do
+  visit "/users/#{@tom.id}"
+  expect(page).to have_content('See all posts')
+end
+it 'When I click a user\'s post, it redirects me to that post\'s show page.' do
+  visit "/users/#{@tom.id}"
+  posts = @users[0].recent_posts
+  unless posts.nil? || posts.empty?
+    click_link posts[0].title
+    expect(page).to have_current_path("/users/#{@tom.id}/posts/#{posts[0].id}")
+  end
+end
+it 'When I click to see all posts, it redirects me to the user\'s post\'s index page.' do
+  visit "/users/#{@tom.id}"
+  click_link 'See all posts'
+  expect(page).to have_current_path("/users/#{@tom.id}/posts")
+end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,8 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{Rails.root}/spec/fixtures"
-
+  
+  config.include Capybara::DSL
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{Rails.root}/spec/fixtures"
-  
+
   config.include Capybara::DSL
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
1. Integration specs

- Use Capybara to write integration tests for each view in your project.

- Think on the flow of things and group the tests of page in a way that makes sense. For example, one test would check for the things in the page and another test for clicking links on it.

**- [ ] User index page:**

> I can see the username of all other users.
> I can see the profile picture for each user.
> I can see the number of posts each user has written.
> When I click on a user, I am redirected to that user's show page.

**- [ ] user show page:**

> I can see the user's profile picture.
> I can see the user's username.
> I can see the number of posts the user has written.
> I can see the user's bio.
> I can see the user's last 3 posts.
> I can see a button that lets me view all of a user's posts.
> When I click a user's post, it redirects me to that post's show page.
> When I click to see all posts, it redirects me to the user's post's index page.

**- [ ] User post index page:**

> - I can see the user's profile picture.
> - I can see the user's username.
> - I can see the number of posts the user has written.
> - I can see a post's title.
> - I can see some of the post's body.
> - I can see the last 5 comments on a post.
> - I can see how many comments a post has.
> - I can see how many likes a post has.
> - I can see a section for pagination if there are more posts than fit on the view.
> - When I click on a post, it redirects me to that post's show page.

**-[ ] Post show page:** 

> I can see the post's title.
> I can see who wrote the post.
> I can see how many comments it has.
> I can see how many likes it has.
> I can see the post body.
> I can see the username of each commentor.
> I can see the comment each commentor left.